### PR TITLE
[commands] add stop command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ clean-migrations:  ## Remove all migrations
 	rm -rf src/database/migrations/versions/*
 
 # Testing
+.PHONY: lint
+lint:  ## Run linter
+	pipenv run flake8 src tests
+
 .PHONY: test
 test:  ## Run tests with coverage
 	pipenv run pytest tests/ -v --cov=src --cov-report=term-missing

--- a/src/bot/handlers/schedules/__init__.py
+++ b/src/bot/handlers/schedules/__init__.py
@@ -1,14 +1,7 @@
 from aiogram import Router
 from aiogram.types import BotCommand
 
-from . import (
-    callbacks,
-    create,
-    list,
-    taken,
-    history,
-)
-
+from . import callbacks, create, history, list, stop, taken
 
 router = Router()
 commands = [
@@ -16,10 +9,16 @@ commands = [
     BotCommand(command="list", description="Show active medications"),
     BotCommand(command="taken", description="Confirm dose taken"),
     BotCommand(command="history", description="Show medication adherence history"),
+    BotCommand(command="stop", description="Stop medication schedule"),
 ]
 
 router.include_routers(
-    callbacks.router, create.router, list.router, taken.router, history.router
+    callbacks.router,
+    create.router,
+    list.router,
+    taken.router,
+    history.router,
+    stop.router,
 )
 
 

--- a/src/bot/handlers/schedules/callbacks_data.py
+++ b/src/bot/handlers/schedules/callbacks_data.py
@@ -3,3 +3,7 @@ from aiogram.filters.callback_data import CallbackData
 
 class DoseCallback(CallbackData, prefix="dose"):
     schedule_id: int
+
+
+class StopScheduleCallbackData(CallbackData, prefix="stop_schedule"):
+    schedule_id: int

--- a/src/bot/handlers/schedules/formatters.py
+++ b/src/bot/handlers/schedules/formatters.py
@@ -5,15 +5,6 @@ from src.services.schedule_service import ScheduleService
 async def format_schedule(
     user: User, schedule: Schedule, service: ScheduleService
 ) -> str:
-    # Get next dose time
-    next_dose = await service.get_next_dose_time(user, schedule)
-
-    # Convert times to user's timezone
-    start_local = user.in_local_time(schedule.start_datetime)
-    end_local = (
-        user.in_local_time(schedule.end_datetime) if schedule.end_datetime else None
-    )
-
     # Base information
     text = (
         f"   💊 Drug: {schedule.drug_name}\n"
@@ -21,14 +12,25 @@ async def format_schedule(
         f"   ⏰ Frequency: {schedule.doses_per_day}x/day\n"
     )
 
-    # Duration information
-    if schedule.duration:
-        end_date = end_local.strftime("%Y-%m-%d") if end_local else "ongoing"
-        text += f"   📅 Duration: {schedule.duration} days\n"
-        text += f"      {start_local.strftime('%Y-%m-%d')} → {end_date}\n"
-    else:
-        text += f"   📅 Since {start_local.strftime('%Y-%m-%d')}\n"
+    # Convert times to user's timezone
+    start_local = user.in_local_time(schedule.start_datetime)
+    end_local = (
+        user.in_local_time(schedule.end_datetime) if schedule.end_datetime else None
+    )
+    end_date = end_local.strftime("%Y-%m-%d") if end_local else "ongoing"
+    duration = schedule.duration
+    if end_local:
+        duration = (end_local - start_local).days
 
+    # Duration information
+    if not end_local:
+        text += f"   📅 Since {start_local.strftime('%Y-%m-%d')}\n"
+    else:
+        text += f"   📅 Duration: {duration} days\n"
+        text += f"      {start_local.strftime('%Y-%m-%d')} → {end_date}\n"
+
+    # Get next dose time
+    next_dose = await service.get_next_dose_time(user, schedule)
     # Next dose information
     if next_dose:
         next_local = user.in_local_time(next_dose)

--- a/src/bot/handlers/schedules/keyboards.py
+++ b/src/bot/handlers/schedules/keyboards.py
@@ -1,17 +1,36 @@
+from typing import Callable
+
+from aiogram.filters.callback_data import CallbackData
 from aiogram.types import InlineKeyboardMarkup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from src.models import Schedule
 
-from .callbacks_data import DoseCallback
+from .callbacks_data import DoseCallback, StopScheduleCallbackData
 
 
-def get_taken_keyboard(schedules: list[Schedule]) -> InlineKeyboardMarkup:
+def get_schedules_keyboard(
+    schedules: list[Schedule],
+    prefix: str,
+    callback_factory: Callable[[Schedule], CallbackData],
+) -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
     for schedule in schedules:
         builder.button(
-            text=f"💊 {schedule.drug_name} ({schedule.dose})",
-            callback_data=DoseCallback(schedule_id=schedule.id).pack(),
+            text=f"{prefix} {schedule.drug_name} ({schedule.dose})",
+            callback_data=callback_factory(schedule).pack(),
         )
     builder.adjust(1)
     return builder.as_markup()
+
+
+def get_taken_keyboard(schedules: list[Schedule]) -> InlineKeyboardMarkup:
+    return get_schedules_keyboard(
+        schedules, "✅", lambda s: DoseCallback(schedule_id=s.id)
+    )
+
+
+def get_stop_keyboard(schedules: list[Schedule]) -> InlineKeyboardMarkup:
+    return get_schedules_keyboard(
+        schedules, "⏹️", lambda s: StopScheduleCallbackData(schedule_id=s.id)
+    )

--- a/src/bot/handlers/schedules/stop.py
+++ b/src/bot/handlers/schedules/stop.py
@@ -1,0 +1,60 @@
+import logging
+
+from aiogram import Router, types
+from aiogram.filters import Command
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import User
+from src.services.schedule_service import ScheduleService
+
+from .callbacks_data import StopScheduleCallbackData
+from .formatters import format_schedule
+from .keyboards import get_stop_keyboard
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+
+@router.message(Command("stop"))
+async def command_stop(message: types.Message, session: AsyncSession, user: User):
+    """
+    Handles the /stop command to initiate the schedule stopping process.
+    """
+    service = ScheduleService(session)
+
+    active_schedules = await service.get_active_schedules(user.id)
+
+    if not active_schedules:
+        await message.answer("ℹ️ You have no active medication schedules.")
+        return
+
+    await message.answer(
+        "Choose a schedule to stop:",
+        reply_markup=get_stop_keyboard(active_schedules),
+    )
+
+
+@router.callback_query(StopScheduleCallbackData.filter())
+async def callback_stop_schedule(
+    query: types.CallbackQuery,
+    callback_data: StopScheduleCallbackData,
+    session: AsyncSession,
+    user: User,
+):
+    """
+    Handles the callback query to stop a specific schedule.
+    """
+    service = ScheduleService(session)
+
+    schedule_id = callback_data.schedule_id
+    logger.info("Stopping schedule with id: %s", schedule_id)
+    try:
+        schedule = await service.stop_schedule(user.id, schedule_id)
+        if isinstance(query.message, types.Message):
+            await query.message.edit_text(
+                f"⏹️ Schedule stopped:\n\n{await format_schedule(user, schedule, service)}"
+            )
+    except Exception as e:
+        logger.error("Failed to stop schedule %s: %s", schedule_id, e)
+        await query.answer(f"Failed to stop schedule {schedule_id}.")
+    await query.answer()

--- a/src/database/migrations/versions/2025_05_17_2044-afb2fc8c80cd_change_end_datetime_to.py
+++ b/src/database/migrations/versions/2025_05_17_2044-afb2fc8c80cd_change_end_datetime_to.py
@@ -1,0 +1,56 @@
+"""Change end_datetime to be non-computed
+
+Revision ID: afb2fc8c80cd
+Revises: 35b67a0ec1f3
+Create Date: 2025-05-17 20:44:21.362646
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "afb2fc8c80cd"
+down_revision: Union[str, None] = "35b67a0ec1f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Drop computed end_datetime column
+    op.drop_column("schedules", "end_datetime")
+
+    # Add new end_datetime column
+    op.add_column(
+        "schedules",
+        sa.Column("end_datetime", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Populate existing rows
+    op.execute(
+        """
+        UPDATE `schedules`
+        SET `end_datetime` = `start_datetime` + INTERVAL `duration` DAY
+        WHERE `duration` IS NOT NULL
+    """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop new columns
+    op.drop_column("schedules", "end_datetime")
+
+    # Restore original computed end_datetime
+    op.add_column(
+        "schedules",
+        sa.Column(
+            "end_datetime",
+            sa.DateTime(timezone=True),
+            sa.Computed("start_datetime + INTERVAL duration DAY"),
+            nullable=True,
+        ),
+    )

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from functools import cached_property
 
 import pytz
-from sqlalchemy import CheckConstraint, Computed, Enum, ForeignKey, String
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database.connector import Base
@@ -82,9 +82,8 @@ class Schedule(Base, TimedModelMixin):
     start_datetime: Mapped[datetime] = mapped_column(
         UTCDateTime(timezone=True)
     )  # Actual start time after delay
-    end_datetime: Mapped[datetime] = mapped_column(
+    end_datetime: Mapped[datetime | None] = mapped_column(
         UTCDateTime(timezone=True),
-        Computed("start_datetime + INTERVAL duration DAY"),
         nullable=True,
     )
 

--- a/src/services/schedule_service.py
+++ b/src/services/schedule_service.py
@@ -222,7 +222,7 @@ class ScheduleService:
 
         if not doses:
             # First dose in a day
-            start_local = now_local
+            start_local = max(now_local, user.in_local_time(schedule.start_datetime))
             return self._validate_next_local(start_local, user.tz).astimezone(
                 timezone.utc
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to stop medication schedules via a new `/stop` command and interactive inline keyboard.
  - Users can now select and stop active medication schedules directly from the app interface.

- **Improvements**
  - Enhanced schedule formatting with dynamic duration and date range display.
  - Refined inline keyboard interactions with reusable components for better consistency.
  - Automatically set schedule end dates when creating schedules with a specified duration.
  - Adjusted next dose time calculation to consider schedule start time and user timezone.

- **Database**
  - Updated schedule end date handling by removing computed columns and explicitly setting end dates for existing records.

- **Testing**
  - Added tests for next dose timing, timezone error handling, and schedule creation error scenarios.

- **Tooling**
  - Added a linter target to the Makefile for code quality checks.
  - Configured Visual Studio Code workspace settings for Python testing with pytest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->